### PR TITLE
bursting exception when trying to read backslash include

### DIFF
--- a/src/com/oecoverage/coverage/ListingFile.java
+++ b/src/com/oecoverage/coverage/ListingFile.java
@@ -109,7 +109,7 @@ public class ListingFile {
 							
 							for (String item : items) {
 							
-								if(!item.contains("&") && item.contains("/")) {
+								if(!item.contains("&") && (item.contains("/") || item.contains("\\"))) {
 									
 									stack.add(item.replace("{", "").replace("}", ""));
 								}


### PR DESCRIPTION
In class **ListingFile**, method **readListingFile**, when reading an include that contained a backslash, the exception "_arrayIndexOutOfBound_" occurred. Because the logic only validated the normal slash