### PR TITLE
exception occurring when trying to read a broken profiler

### DIFF
--- a/src/com/oecoverage/coverage/ListingFile.java
+++ b/src/com/oecoverage/coverage/ListingFile.java
@@ -109,7 +109,7 @@ public class ListingFile {
 							
 							for (String item : items) {
 							
-								if(!item.contains("&") && item.contains("/")) {
+								if(!item.contains("&") && (item.contains("/") || item.contains("\\"))) {
 									
 									stack.add(item.replace("{", "").replace("}", ""));
 								}

--- a/src/com/oecoverage/coverage/SonarCoverage.java
+++ b/src/com/oecoverage/coverage/SonarCoverage.java
@@ -75,7 +75,11 @@ public class SonarCoverage {
 		// Read all profilers files found in the provided path.
 		for (int i = 0; i < files.size(); i++) {
 			if (files.get(i).getName().indexOf(".out") > 0) {
-				this.profiler.readProfiler(files.get(i).getAbsolutePath());
+				try {
+					this.profiler.readProfiler(files.get(i).getAbsolutePath());	
+				} catch (Exception e)  {
+					e.printStackTrace();
+				}
 			}
 		}
 		


### PR DESCRIPTION
when a corrupted profiler is generated and it is attempted to be read by the **SonarCoverage** method the exception "_NumberFormatException_" occurs.

- Below are some cases where the profiler is improperly generated

![image](https://user-images.githubusercontent.com/36779308/65513799-54d06800-deb2-11e9-80d7-e131407a396c.png)
![image](https://user-images.githubusercontent.com/36779308/65513409-990f3880-deb1-11e9-96c0-aa484a9446f6.png)
